### PR TITLE
removed bug with session manager menu 

### DIFF
--- a/wplay/utils/session_manager.py
+++ b/wplay/utils/session_manager.py
@@ -96,7 +96,7 @@ def __verify_answers(answers_menu, data_filenames, question_overwrite):
     # Handle when person choose 'Restore a session'
     if answers_menu['user_options'] == user_options['restore']:
         if answers_menu['restore'] == '<---Go-back---':
-            session_manager()
+            username, save_session = session_manager()
         else:
             username = answers_menu['restore']
             save_session = True
@@ -115,7 +115,7 @@ def __verify_answers(answers_menu, data_filenames, question_overwrite):
     elif answers_menu['user_options'] == user_options['delete']:
         if len(answers_menu['delete']) > 0:
             [__delete_session_data(user_data_folder_path / username) for username in answers_menu['delete']]
-        session_manager()
+        username, save_session = session_manager()
 
     # Handle when person choose 'Exit'
     elif answers_menu['user_options'] == user_options['exit']:


### PR DESCRIPTION
**Changes made:**
In the previous state the return values from session_manager() were not saved after their function execution in recursion. So, it is returning username and save_session as None. so, I declared the variables for storing the returned values of function.

**Fixes/Closes**
Solved issue #121 
