### PR TITLE
#124 alternate target search

### DIFF
--- a/wplay/messageblast.py
+++ b/wplay/messageblast.py
@@ -14,7 +14,11 @@ logger = Logger.setup_logger('logs',logs_path/'logs.log')
 async def blast(target):
     page, _ = await browser_config.configure_browser_and_load_whatsapp()
     if target is not None:
-        await target_search.search_and_select_target(page, target)
+        try:
+            await target_search.search_and_select_target(page, target)
+        except Exception as e:
+            print(e)
+            await target_search.search_and_select_target_without_new_chat_button(page,target)
     else:
         await target_select.manual_select_target(page)
     message = io.ask_user_for_message_breakline_mode()

--- a/wplay/messagetimer.py
+++ b/wplay/messagetimer.py
@@ -17,7 +17,11 @@ logger = Logger.setup_logger('logs',logs_path/'logs.log')
 async def msgTimer(target):
     page, _ = await browser_config.configure_browser_and_load_whatsapp()
     if target is not None:
-        await target_search.search_and_select_target(page, target)
+        try:
+            await target_search.search_and_select_target(page, target)
+        except Exception as e:
+            print(e)
+            await target_search.search_and_select_target_without_new_chat_button(page, target)
     else:
         await target_select.manual_select_target(page)
     # Region INPUTS

--- a/wplay/onlinetracker.py
+++ b/wplay/onlinetracker.py
@@ -19,7 +19,11 @@ logger = Logger.setup_logger('logs',logs_path/'logs.log')
 async def tracker(target):
     page, _ = await browser_config.configure_browser_and_load_whatsapp()
     if target is not None:
-        target_name = await target_search.search_and_select_target(page, target, hide_groups = True)
+        try:
+            target_name = await target_search.search_and_select_target(page, target, hide_groups = True)
+        except Exception as e:
+            print(e)
+            target_name = await target_search.search_and_select_target_without_new_chat_button(page,target,hide_groups=True)
     else:
         target_name = await target_select.manual_select_target(page, hide_groups = True)
     Path(data_folder_path / 'tracking_data').mkdir(parents = True, exist_ok = True)

--- a/wplay/utils/helpers.py
+++ b/wplay/utils/helpers.py
@@ -28,7 +28,11 @@ whatsapp_selectors_dict = {
                                     'span > div > span > div > div > div:first-child > div:nth-child(5)>div>div>div>div:first-child>span',
     'contact_info_page_group_elements': '#app > div > div > div:nth-child(2) > div:last-of-type > '
                                     'span > div > span > div > div > div:first-child > div:nth-child(5)>div:nth-child(2)>div>div',
-    'contact_info_page_close_button': '#app > div > div > div:nth-child(2) > div:last-of-type > span > div > span > div > header > div > div > button'
+    'contact_info_page_close_button': '#app > div > div > div:nth-child(2) > div:last-of-type > span > div > span > div > header > div > div > button',
+    'chat_or_message_search': '#side > div:nth-child(3) > div > label > div > div:last-child',
+    'chats_groups_messages_elements': '#side > div:last-child > div > div > div > div',
+    'contact_element': 'div > div > div > div:last-child > div:first-child > div:first-child > div > span > span > span[class^="matched_text"]',
+    'group_element': 'div > div > div > div:last-child > div:first-child > div:first-child > div > span > span[class^="matched_text"]',
 }
 # endregion
 

--- a/wplay/utils/helpers.py
+++ b/wplay/utils/helpers.py
@@ -31,8 +31,8 @@ whatsapp_selectors_dict = {
     'contact_info_page_close_button': '#app > div > div > div:nth-child(2) > div:last-of-type > span > div > span > div > header > div > div > button',
     'chat_or_message_search': '#side > div:nth-child(3) > div > label > div > div:last-child',
     'chats_groups_messages_elements': '#side > div:last-child > div > div > div > div',
-    'contact_element': 'div > div > div > div:last-child > div:first-child > div:first-child > div > span > span > span[class^="matched_text"]',
-    'group_element': 'div > div > div > div:last-child > div:first-child > div:first-child > div > span > span[class^="matched_text"]',
+    'contact_element': 'span > span > span[class^="matched-text"]',
+    'group_element': 'span > span[class^="matched-text"]',
 }
 # endregion
 

--- a/wplay/utils/helpers.py
+++ b/wplay/utils/helpers.py
@@ -32,7 +32,7 @@ whatsapp_selectors_dict = {
     'chat_or_message_search': '#side > div:nth-child(3) > div > label > div > div:last-child',
     'chats_groups_messages_elements': '#side > div:last-child > div > div > div > div',
     'contact_element': 'span > span > span[class^="matched-text"]',
-    'group_element': 'span > span[class^="matched-text"]',
+    'group_element': 'div:last-child > div:first-child > div:first-child > div > span > span[class^="matched-text"]',
 }
 # endregion
 

--- a/wplay/utils/target_search.py
+++ b/wplay/utils/target_search.py
@@ -65,7 +65,7 @@ async def search_and_select_target_without_new_chat_button(page,target, hide_gro
     await __type_in_chat_or_message_search(page,target)
     chats_messages_groups_elements_list = await __get_chats_messages_groups_elements(page)
     contact_name_index_tuple_list = await __get_contacts_matched_with_query(chats_messages_groups_elements_list)
-    group_name_index_tuple_list = await __get_groups_matched_with_query(chats_messages_groups_elements_list)
+    group_name_index_tuple_list = await __get_groups_matched_with_query(chats_messages_groups_elements_list,hide_groups)
     target_tuple = (contact_name_index_tuple_list,group_name_index_tuple_list)
     __print_target_tuple(target_tuple)
     target_index_chosen = __ask_user_to_choose_the_filtered_target(target_tuple)
@@ -82,7 +82,7 @@ async def search_and_select_target_without_new_chat_button(page,target, hide_gro
         await close_contact_info_page(page)
     else:
         __print_selected_target_title(target_name)
-
+    await __wait_for_message_area(page)
     return target_name
 
 
@@ -137,8 +137,12 @@ async def __get_contacts_matched_with_query(chats_groups_messages_elements_list)
     return contacts_to_choose_from
 
 
-async def __get_groups_matched_with_query(chats_groups_messages_elements_list):
+async def __get_groups_matched_with_query(chats_groups_messages_elements_list,hide_groups):
     groups_to_choose_from = []
+
+    if hide_groups:
+        return groups_to_choose_from
+
     get_group_node_title_function = 'node => node.parentNode.getAttribute("title")'
     for idx, element in enumerate(chats_groups_messages_elements_list):
         try:

--- a/wplay/utils/target_search.py
+++ b/wplay/utils/target_search.py
@@ -63,6 +63,7 @@ async def search_and_select_target(page, target, hide_groups=False):
 async def search_and_select_target_without_new_chat_button(page,target, hide_groups=False):
     await __type_in_chat_or_message_search(page,target)
     chats_messages_groups_elements_list = await __get_chats_messages_groups_elements(page)
+    index_contact_name_tuple_list = await __get_contacts_matched_with_query(chats_messages_groups_elements_list)
     target_name="name"
     return target_name
 
@@ -97,6 +98,16 @@ async def __get_chats_messages_groups_elements(page):
     except Exception as e:
         print(e)
         exit()
+
+async def __get_contacts_matched_with_query(chats_groups_messages_elements_list):
+    contacts_to_choose_from = []
+    get_contact_node_title_function = 'node => node.parentNode.getAttribute("title")'
+    try:
+        contacts_to_choose_from = [(idx,await e.querySelectorEval(whatsapp_selectors_dict['contact_element'],get_contact_node_title_function))
+                                   for idx,e in enumerate(chats_groups_messages_elements_list)]
+    except Exception as e:
+        print(e)
+    return contacts_to_choose_from
 
 
 async def get_complete_info_on_target(page):

--- a/wplay/utils/target_search.py
+++ b/wplay/utils/target_search.py
@@ -69,9 +69,20 @@ async def search_and_select_target_without_new_chat_button(page,target, hide_gro
     target_tuple = (contact_name_index_tuple_list,group_name_index_tuple_list)
     __print_target_tuple(target_tuple)
     target_index_chosen = __ask_user_to_choose_the_filtered_target(target_tuple)
+
+    '''chosen_target will be a tuple (a,b) such that a is the name of the target and b is the 
+    index of that element in chats_messages_groups_elements_list'''
+
     chosen_target = __get_choosed_target(target_tuple, target_index_chosen)
     await __open_selected_chat(chosen_target[1],chats_messages_groups_elements_list)
-    target_name="name"
+    target_name = chosen_target[0]
+    if any(chosen_target[0] in i for i in contact_name_index_tuple_list):
+        complete_target_info = await get_complete_info_on_target(page)
+        print_complete_target_info(complete_target_info)
+        await close_contact_info_page(page)
+    else:
+        __print_selected_target_title(target_name)
+
     return target_name
 
 

--- a/wplay/utils/target_search.py
+++ b/wplay/utils/target_search.py
@@ -57,8 +57,15 @@ async def search_and_select_target(page, target, hide_groups=False):
         __print_selected_target_title(target_focused_title)
     __check_target_focused_title(page, target, target_focused_title)
     await __wait_for_message_area(page)
-
     return target_focused_title
+
+
+async def search_and_select_target_without_new_chat_button(page,target, hide_groups=False):
+    await __type_in_chat_or_message_search(page,target)
+    target_name="name"
+    return target_name
+
+
 # endregion
 
 
@@ -68,6 +75,20 @@ logger = Logger.setup_logger('logs',logs_path/'logs.log')
 
 
 # region SEARCH AND SELECT TARGET
+async def __type_in_chat_or_message_search(page,target):
+    try:
+        print(f'Looking for: {target}')
+        await page.waitForSelector(
+            whatsapp_selectors_dict['chat_or_message_search'],
+            visible=True
+        )
+        await page.type(whatsapp_selectors_dict['chat_or_message_search'], target)
+        await page.waitFor(3000)
+    except Exception as e:
+        print(e)
+        exit()
+
+
 async def get_complete_info_on_target(page):
     contact_page_elements = []
     try:

--- a/wplay/utils/target_search.py
+++ b/wplay/utils/target_search.py
@@ -70,6 +70,7 @@ async def search_and_select_target_without_new_chat_button(page,target, hide_gro
     __print_target_tuple(target_tuple)
     target_index_chosen = __ask_user_to_choose_the_filtered_target(target_tuple)
     chosen_target = __get_choosed_target(target_tuple, target_index_chosen)
+    await __open_selected_chat(chosen_target[1],chats_messages_groups_elements_list)
     target_name="name"
     return target_name
 
@@ -140,6 +141,14 @@ async def __get_groups_matched_with_query(chats_groups_messages_elements_list):
             print(e)
 
     return groups_to_choose_from
+
+
+async def __open_selected_chat(target_index,chats_messages_groups_elements_list):
+    try:
+        await chats_messages_groups_elements_list[target_index].click()
+    except Exception as e:
+        print(f"This target doesn't exist! Error: {str(e)}")
+        exit()
 
 
 async def get_complete_info_on_target(page):

--- a/wplay/utils/target_search.py
+++ b/wplay/utils/target_search.py
@@ -62,6 +62,7 @@ async def search_and_select_target(page, target, hide_groups=False):
 
 async def search_and_select_target_without_new_chat_button(page,target, hide_groups=False):
     await __type_in_chat_or_message_search(page,target)
+    chats_messages_groups_elements_list = await __get_chats_messages_groups_elements(page)
     target_name="name"
     return target_name
 
@@ -84,6 +85,15 @@ async def __type_in_chat_or_message_search(page,target):
         )
         await page.type(whatsapp_selectors_dict['chat_or_message_search'], target)
         await page.waitFor(3000)
+    except Exception as e:
+        print(e)
+        exit()
+
+
+async def __get_chats_messages_groups_elements(page):
+    try:
+        chats_messages_groups_elements_list = await page.querySelectorAll(whatsapp_selectors_dict['chats_groups_messages_elements'])
+        return chats_messages_groups_elements_list
     except Exception as e:
         print(e)
         exit()

--- a/wplay/utils/target_search.py
+++ b/wplay/utils/target_search.py
@@ -65,6 +65,7 @@ async def search_and_select_target_without_new_chat_button(page,target, hide_gro
     await __type_in_chat_or_message_search(page,target)
     chats_messages_groups_elements_list = await __get_chats_messages_groups_elements(page)
     index_contact_name_tuple_list = await __get_contacts_matched_with_query(chats_messages_groups_elements_list)
+    index_group_name_tuple_list = await __get_groups_matched_with_query(chats_messages_groups_elements_list)
     target_name="name"
     return target_name
 
@@ -118,6 +119,23 @@ async def __get_contacts_matched_with_query(chats_groups_messages_elements_list)
             print(e)
 
     return contacts_to_choose_from
+
+
+async def __get_groups_matched_with_query(chats_groups_messages_elements_list):
+    groups_to_choose_from = []
+    get_group_node_title_function = 'node => node.parentNode.getAttribute("title")'
+    for idx, element in enumerate(chats_groups_messages_elements_list):
+        try:
+            group_name = await element.querySelectorEval(whatsapp_selectors_dict['group_element'],
+                                                         get_group_node_title_function)
+            groups_to_choose_from.append((idx, group_name))
+        except ElementHandleError:
+            # if it is not a contact element, move to the next one
+            continue
+        except Exception as e:
+            print(e)
+
+    return groups_to_choose_from
 
 
 async def get_complete_info_on_target(page):

--- a/wplay/utils/target_search.py
+++ b/wplay/utils/target_search.py
@@ -64,8 +64,12 @@ async def search_and_select_target(page, target, hide_groups=False):
 async def search_and_select_target_without_new_chat_button(page,target, hide_groups=False):
     await __type_in_chat_or_message_search(page,target)
     chats_messages_groups_elements_list = await __get_chats_messages_groups_elements(page)
-    index_contact_name_tuple_list = await __get_contacts_matched_with_query(chats_messages_groups_elements_list)
-    index_group_name_tuple_list = await __get_groups_matched_with_query(chats_messages_groups_elements_list)
+    contact_name_index_tuple_list = await __get_contacts_matched_with_query(chats_messages_groups_elements_list)
+    group_name_index_tuple_list = await __get_groups_matched_with_query(chats_messages_groups_elements_list)
+    target_tuple = (contact_name_index_tuple_list,group_name_index_tuple_list)
+    __print_target_tuple(target_tuple)
+    target_index_chosen = __ask_user_to_choose_the_filtered_target(target_tuple)
+    chosen_target = __get_choosed_target(target_tuple, target_index_chosen)
     target_name="name"
     return target_name
 
@@ -111,7 +115,7 @@ async def __get_contacts_matched_with_query(chats_groups_messages_elements_list)
     for idx, element in enumerate(chats_groups_messages_elements_list):
         try:
             contact_name = await element.querySelectorEval(whatsapp_selectors_dict['contact_element'],get_contact_node_title_function)
-            contacts_to_choose_from.append((idx,contact_name))
+            contacts_to_choose_from.append((contact_name,idx))
         except ElementHandleError:
             # if it is not a contact element, move to the next one
             continue
@@ -128,7 +132,7 @@ async def __get_groups_matched_with_query(chats_groups_messages_elements_list):
         try:
             group_name = await element.querySelectorEval(whatsapp_selectors_dict['group_element'],
                                                          get_group_node_title_function)
-            groups_to_choose_from.append((idx, group_name))
+            groups_to_choose_from.append((group_name,idx))
         except ElementHandleError:
             # if it is not a contact element, move to the next one
             continue

--- a/wplay/utils/target_search.py
+++ b/wplay/utils/target_search.py
@@ -70,8 +70,8 @@ async def search_and_select_target_without_new_chat_button(page,target, hide_gro
     __print_target_tuple(target_tuple)
     target_index_chosen = __ask_user_to_choose_the_filtered_target(target_tuple)
 
-    '''chosen_target will be a tuple (a,b) such that a is the name of the target and b is the 
-    index of that element in chats_messages_groups_elements_list'''
+    #chosen_target will be a tuple (a,b) such that a is the name of the target and b is the
+    #index of that element in chats_messages_groups_elements_list
 
     chosen_target = __get_choosed_target(target_tuple, target_index_chosen)
     await __open_selected_chat(chosen_target[1],chats_messages_groups_elements_list)

--- a/wplay/wchat.py
+++ b/wplay/wchat.py
@@ -15,10 +15,11 @@ async def chat(target):
     logger.info("Chatting with target")
     page, _ = await browser_config.configure_browser_and_load_whatsapp()
     if target is not None:
-        await target_search.search_and_select_target(page, target)
+        #await target_search.search_and_select_target(page, target)
+        await target_search.search_and_select_target_without_new_chat_button(page,target)
     else:
         await target_select.manual_select_target(page)
 
-    while True:
-        message = io.ask_user_for_message_breakline_mode()
-        await io.send_message(page, message)
+    # while True:
+    #     message = io.ask_user_for_message_breakline_mode()
+    #     await io.send_message(page, message)

--- a/wplay/wchat.py
+++ b/wplay/wchat.py
@@ -14,12 +14,16 @@ logger = Logger.setup_logger('logs',logs_path/'logs.log')
 async def chat(target):
     logger.info("Chatting with target")
     page, _ = await browser_config.configure_browser_and_load_whatsapp()
+
     if target is not None:
-        #await target_search.search_and_select_target(page, target)
-        await target_search.search_and_select_target_without_new_chat_button(page,target)
+        try:
+            await target_search.search_and_select_target(page, target)
+        except Exception as e:
+            print(e)
+            await target_search.search_and_select_target_without_new_chat_button(page, target)
     else:
         await target_select.manual_select_target(page)
 
-    # while True:
-    #     message = io.ask_user_for_message_breakline_mode()
-    #     await io.send_message(page, message)
+    while True:
+        message = io.ask_user_for_message_breakline_mode()
+        await io.send_message(page, message)


### PR DESCRIPTION
This is an approach to solve issue 124. It uses the normal search box on the whatsapp web website to find contacts and groups that match the search query.
Currently this search method has been added as an alternative in case an exception arises from the current search method