### PR TITLE
Get selected group details

### DIFF
--- a/wplay/utils/helpers.py
+++ b/wplay/utils/helpers.py
@@ -38,7 +38,10 @@ whatsapp_selectors_dict = {
     'send_file' : '#app > div > div > div > div > span > div > span > div > div > div > span > div > div > span',
     'profile_photo_element': '#side > header > div > div > img',
     'about_edit_button_element': '#app > div > div > div > div > span > div > div > div > div:nth-child(4) > div > div > span > div > span',
-    'about_text_area': '#app > div > div > div > div > span > div > div > div > div:nth-child(4) > div > div > div > div'
+    'about_text_area': '#app > div > div > div > div > span > div > div > div > div:nth-child(4) > div > div > div > div',
+    'contact_info_page_target_group_name_element': 'div:nth-child(2)>div>div> div:last-of-type',
+    'contact_info_page_target_group_creation_info_element': ':scope > div:last-child > span',
+    'contact_info_page_target_group_description_element': ":scope > div:last-child span:first-of-type"
 }
 # endregion
 

--- a/wplay/utils/helpers.py
+++ b/wplay/utils/helpers.py
@@ -41,7 +41,8 @@ whatsapp_selectors_dict = {
     'about_text_area': '#app > div > div > div > div > span > div > div > div > div:nth-child(4) > div > div > div > div',
     'contact_info_page_target_group_name_element': 'div:nth-child(2)>div>div> div:last-of-type',
     'contact_info_page_target_group_creation_info_element': ':scope > div:last-child > span',
-    'contact_info_page_target_group_description_element': ":scope > div:last-child span:first-of-type"
+    'contact_info_page_target_group_description_element': ':scope > div:last-child span:first-of-type',
+    'contact_info_page_target_group_member_elements': ':scope > div:nth-child(4) > div > div'
 }
 # endregion
 

--- a/wplay/utils/target_search.py
+++ b/wplay/utils/target_search.py
@@ -55,16 +55,7 @@ async def search_and_select_target(page, target, hide_groups=False):
     choosed_target = __get_choosed_target(target_tuple, target_index_choosed)
     await __navigate_to_target(page, choosed_target)
     target_focused_title = await __get_focused_target_title(page, target)
-    complete_target_info={}
-    if any(choosed_target[0] in i for i in contact_tuple):
-        complete_target_info = await __get_complete_info_on_target(page)
-        __print_complete_target_info(complete_target_info)
-        await __close_contact_info_page(page)
-    else:
-        complete_target_info = await __get_complete_info_on_group(page)
-        __print_complete_target_info(complete_target_info)
-        await __close_contact_info_page(page)
-        # __print_selected_target_title(target_focused_title)
+    await __display_complete_target_info(page,choosed_target,contact_tuple)
     __check_target_focused_title(page, target, target_focused_title)
     await __wait_for_message_area(page)
     return target_focused_title
@@ -86,12 +77,7 @@ async def search_and_select_target_without_new_chat_button(page,target, hide_gro
     chosen_target = __get_choosed_target(target_tuple, target_index_chosen)
     await __open_selected_chat(chosen_target[1],chats_messages_groups_elements_list)
     target_name = chosen_target[0]
-    if any(chosen_target[0] in i for i in contact_name_index_tuple_list):
-        complete_target_info = await __get_complete_info_on_target(page)
-        __print_complete_target_info(complete_target_info)
-        await __close_contact_info_page(page)
-    else:
-        __print_selected_target_title(target_name)
+    await __display_complete_target_info(page, chosen_target, contact_name_index_tuple_list)
     await __wait_for_message_area(page)
     return target_name
 
@@ -114,6 +100,21 @@ async def __get_number_of_all_contacts(page,contact_name_index_tuple_list, chats
             complete_target_info = {}
             await __get_contact_about_and_phone(contact_page_elements[3], complete_target_info)
             contact_name_index_tuple_list[index] = (contact_name_index_tuple[0] + " : " + complete_target_info['Mobile'],contact_name_index_tuple[1])
+            await __close_contact_info_page(page)
+    except Exception as e:
+        print(e)
+
+
+async def __display_complete_target_info(page,target_tuple,contact_tuple):
+    complete_target_info = {}
+    try:
+        if any(target_tuple[0] in i for i in contact_tuple):
+            complete_target_info = await __get_complete_info_on_target(page)
+            __print_complete_target_info(complete_target_info)
+            await __close_contact_info_page(page)
+        else:
+            complete_target_info = await __get_complete_info_on_group(page)
+            __print_complete_target_info(complete_target_info)
             await __close_contact_info_page(page)
     except Exception as e:
         print(e)
@@ -248,12 +249,21 @@ async def __get_target_group_description(element,complete_target_info):
 
 async def __get_target_group_members(element, complete_target_info):
     try:
+        children_elements = await element.querySelectorAll(':scope > div')
+        if len(children_elements) <= 2:
+            target_group_members_selector = ':scope > div:last-child > div > div'
+        elif len(children_elements) == 3:
+            target_group_members_selector = ':scope > div:nth-child(2) > div > div'
+        else:
+            target_group_members_selector = whatsapp_selectors_dict['contact_info_page_target_group_member_elements']
+
         target_group_member_elements = await element.querySelectorAll\
-            (whatsapp_selectors_dict['contact_info_page_target_group_member_elements'])
+            (target_group_members_selector)
+
         group_member_name_selector = ':scope span[title]'
         get_element_title_function = 'e => e.getAttribute("title")'
         complete_target_info['Members'] = [await ele.querySelectorEval(group_member_name_selector,get_element_title_function)
-                                           for ele in target_group_member_elements]
+                                         for ele in target_group_member_elements]
     except Exception as e:
         print(e)
 

--- a/wplay/utils/target_search.py
+++ b/wplay/utils/target_search.py
@@ -212,6 +212,7 @@ async def __get_complete_info_on_group(page):
         complete_target_group_info = {}
         await __get_target_group_name(contact_page_elements[0],complete_target_group_info)
         await __get_target_group_creation_info(contact_page_elements[0],complete_target_group_info)
+        await __get_target_group_description(contact_page_elements[1],complete_target_group_info)
         return complete_target_group_info
     except Exception as e:
         print(e)
@@ -231,6 +232,23 @@ async def __get_target_group_creation_info(element, complete_target_info):
         get_inner_text_function = 'e => e.innerText'
         complete_target_info['Creation Info'] = await element.querySelectorEval\
             (whatsapp_selectors_dict['contact_info_page_target_group_creation_info_element'],get_inner_text_function)
+    except Exception as e:
+        print(e)
+
+
+async def __get_target_group_description(element,complete_target_info):
+    try:
+        get_inner_text_function = 'e => e.innerText'
+        complete_target_info['Description'] = await element.querySelectorEval \
+            (whatsapp_selectors_dict['contact_info_page_target_group_description_element'], get_inner_text_function)
+    except Exception as e:
+        print(e)
+
+
+async def __get_target_group_members(element, complete_target_info):
+    try:
+        target_group_member_elements = await element.querySelectorAll\
+            (whatsapp_selectors_dict['contact_info_page_target_group_member_elements'])
     except Exception as e:
         print(e)
 

--- a/wplay/utils/target_search.py
+++ b/wplay/utils/target_search.py
@@ -55,12 +55,16 @@ async def search_and_select_target(page, target, hide_groups=False):
     choosed_target = __get_choosed_target(target_tuple, target_index_choosed)
     await __navigate_to_target(page, choosed_target)
     target_focused_title = await __get_focused_target_title(page, target)
+    complete_target_info={}
     if any(choosed_target[0] in i for i in contact_tuple):
         complete_target_info = await __get_complete_info_on_target(page)
         __print_complete_target_info(complete_target_info)
         await __close_contact_info_page(page)
     else:
-        __print_selected_target_title(target_focused_title)
+        complete_target_info = await __get_complete_info_on_group(page)
+        __print_complete_target_info(complete_target_info)
+        await __close_contact_info_page(page)
+        # __print_selected_target_title(target_focused_title)
     __check_target_focused_title(page, target, target_focused_title)
     await __wait_for_message_area(page)
     return target_focused_title
@@ -113,6 +117,7 @@ async def __get_number_of_all_contacts(page,contact_name_index_tuple_list, chats
             await __close_contact_info_page(page)
     except Exception as e:
         print(e)
+
 
 async def __type_in_chat_or_message_search(page,target):
     try:
@@ -200,6 +205,36 @@ async def __get_complete_info_on_target(page):
         print(e)
 
 
+async def __get_complete_info_on_group(page):
+    try:
+        await __open_target_chat_info_page(page)
+        contact_page_elements = await __get_contact_page_elements(page)
+        complete_target_group_info = {}
+        await __get_target_group_name(contact_page_elements[0],complete_target_group_info)
+        await __get_target_group_creation_info(contact_page_elements[0],complete_target_group_info)
+        return complete_target_group_info
+    except Exception as e:
+        print(e)
+
+
+async def __get_target_group_name(element, complete_target_info):
+    try:
+        get_inner_text_function = 'e => e.innerText'
+        complete_target_info['Name'] = await element.querySelectorEval\
+            (whatsapp_selectors_dict['contact_info_page_target_group_name_element'],get_inner_text_function)
+    except Exception as e:
+        print(e)
+
+
+async def __get_target_group_creation_info(element, complete_target_info):
+    try:
+        get_inner_text_function = 'e => e.innerText'
+        complete_target_info['Creation Info'] = await element.querySelectorEval\
+            (whatsapp_selectors_dict['contact_info_page_target_group_creation_info_element'],get_inner_text_function)
+    except Exception as e:
+        print(e)
+
+
 async def __open_target_chat_info_page(page):
     try:
         await page.waitForSelector(
@@ -224,7 +259,6 @@ async def __get_contact_page_elements(page):
         return contact_page_elements
     except Exception as e:
         print(e)
-
 
 
 async def __get_contact_name_info(contact_name_element,complete_target_info):

--- a/wplay/utils/target_search.py
+++ b/wplay/utils/target_search.py
@@ -213,6 +213,7 @@ async def __get_complete_info_on_group(page):
         await __get_target_group_name(contact_page_elements[0],complete_target_group_info)
         await __get_target_group_creation_info(contact_page_elements[0],complete_target_group_info)
         await __get_target_group_description(contact_page_elements[1],complete_target_group_info)
+        await __get_target_group_members(contact_page_elements[4],complete_target_group_info)
         return complete_target_group_info
     except Exception as e:
         print(e)
@@ -249,6 +250,10 @@ async def __get_target_group_members(element, complete_target_info):
     try:
         target_group_member_elements = await element.querySelectorAll\
             (whatsapp_selectors_dict['contact_info_page_target_group_member_elements'])
+        group_member_name_selector = ':scope span[title]'
+        get_element_title_function = 'e => e.getAttribute("title")'
+        complete_target_info['Members'] = [await ele.querySelectorEval(group_member_name_selector,get_element_title_function)
+                                           for ele in target_group_member_elements]
     except Exception as e:
         print(e)
 
@@ -328,8 +333,8 @@ async def __close_contact_info_page(page):
 
 def __print_complete_target_info(complete_target_info):
     for key in complete_target_info.keys():
-        if key == "Groups":
-            print("Groups:")
+        if key == "Groups" or key == "Members":
+            print(key + ":")
             print(*complete_target_info[key], sep=",")
         else:
             print(f'{key}: {complete_target_info[key]} ')


### PR DESCRIPTION
Issue that this pull request solves
Closes: #260 

Proposed changes
If the target selected is a group, the user will be able to see the following info about it:
1. Group name
2. Group creation info
3. Group description
4. Group members


Types of changes


 Bugfix (non-breaking change which fixes an issue)
 New feature (non-breaking change which adds functionality)

Checklist

 My code follows the style guidelines of this project
 I have performed a self-review of my own code
 I have made corresponding changes to the documentation

How to use this feature:
1. python -m wplay -wchat group-name
2. Choose target
![image](https://user-images.githubusercontent.com/37807893/78458657-b7f84e00-76d0-11ea-8609-d87fca2d73c0.png)
