### PR TITLE
The updater code for telegram bot resolved

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .userData
 tracking_data
 data
+telegram_token.pkl
 
 # Byte-compiled / optimized / DLL files
 wplay.egg-info/

--- a/wplay/telegram_bot.py
+++ b/wplay/telegram_bot.py
@@ -2,6 +2,7 @@
 import tkinter
 from tkinter import filedialog
 from pathlib import Path
+import pickle
 
 from telegram.ext import CommandHandler, Updater
 from wplay.utils.helpers import data_folder_path
@@ -62,7 +63,24 @@ def telegram_status(name):
     status_file_path = ask_where_are_the_status_file()
     # Add bot token
     global TOKEN
-    TOKEN = input("enter token: ")
+    new_token = False
+    token_file_path = "wplay/telegram_token.pkl"
+    if Path(token_file_path).exists():
+        user_choice = input(
+            "Do you want to use last saved token (Y) or enter new token (N): "
+        )
+        if user_choice in "Yy":
+            with open(token_file_path, "rb") as token_file:
+                TOKEN = pickle.load(token_file)
+        else:
+            new_token = True
+    else:
+        new_token = True
+    if new_token:
+        TOKEN = input("Enter token: ")
+        with open(token_file_path, "wb") as token_file:
+            pickle.dump(TOKEN, token_file)
+
     # Added all the essential command handlers
     updater = Updater(TOKEN)
     dp = updater.dispatcher


### PR DESCRIPTION
## Issue that this pull request solves

Closes: #154  (issue number)

## Proposed changes

Brief description of what is fixed or changed:
  * The Telegram Bot `TOKEN` entered by the user is saved in a `.pkl` file, that the user can opt to reuse for the next session. After this change, the user need not keep his `TOKEN` handy before executing the program each time.
  * Added `telegram_token.pkl` to `.gitignore` to avoid commiting any such `TOKEN`s to the repository.

## Types of changes

_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (Documentation content changed)
- [ ] Other (please describe): 

## Checklist

_Put an `x` in the boxes that apply_

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Screenshots

![image](https://user-images.githubusercontent.com/39518771/79680965-1c6bef00-8233-11ea-8fbb-7f77be5c2cf7.png)


## Other information

Though the first message was sent correctly to the Telegram Bot, unfortunately, further online statuses were not sent when tested. I'm certain this wasn't caused by the changes proposed by this PR. I believe it has something to deal with the status file selected and it's processing, and feel it lies beyond the scope of this issue.

@rpotter12 @xandao6 