### PR TITLE
Receive messages in wchat script successfully in terminal chat whole chat displayed automatically.

### DIFF
--- a/wplay/terminal_chat.py
+++ b/wplay/terminal_chat.py
@@ -7,6 +7,7 @@ from wplay.utils import target_select
 from wplay.utils import io
 from wplay.utils.Logger import Logger
 from wplay.utils.helpers import logs_path
+from colorama import Fore, Style
 # endregion
 
 
@@ -30,13 +31,14 @@ async def chat(target):
                     target
                     )
     else:
-        await target_select.manual_select_target(page)
+        target = await target_select.manual_select_target(page)
 
     print("\033[91m {}\033[00m".format("\nType '...' in a new line or alone in the message to change target person.\nType '#_FILE' to send Image/Video/Documentd etc.\n"))
 
     while True:
+        await getMessages(page, target)
         message: list[str] = io.ask_user_for_message_breakline_mode()
-
+        
         if '...' in message:
             message.remove('...')
             await io.send_message(page, message)
@@ -46,10 +48,45 @@ async def chat(target):
             else:
                 await target_select.manual_select_target(page)
             message = io.ask_user_for_message_breakline_mode()
+        if 'switch' in message:
+            await getMessages(page, target)
 
         # File Share:
         if '#_FILE' in message:
             message.remove('#_FILE')
             await io.send_file(page)
-
+        
         await io.send_message(page, message)
+# import threading
+
+# def printit():
+#     threading.Timer(5.0, printit).start()
+#     print ("Hello, World!")
+# printit() 
+
+lastOutgoingMessage = ''
+
+async def getMessages(pg, tg):
+    selector = "#main > div > div > div > div > div > div > div > div"
+    selector_sender = "#main > div > div > div > div > div > div > div > div > div.copyable-text"
+    try:
+        # Getting all the messages of the chat
+        await pg.waitForSelector(selector)
+        values = await pg.evaluate(f'''() => [...document.querySelectorAll('{selector}')]
+                                                    .map(element => element.textContent)''')
+        sender = await pg.evaluate(f'''() => [...document.querySelectorAll('{selector_sender}')]
+                                                    .map(element => element.getAttribute("data-pre-plain-text"))''')
+        lastMessage = values[-1]
+        last_message_sender = sender[-1]
+        last_message_time = sender[-1].split(',')
+        last_message_time = last_message_time[0].replace('[', '')
+        lastMessage = lastMessage.replace(last_message_time, '')
+    except Exception as e:
+        print(e)
+        lastMessage = ""
+    global lastOutgoingMessage
+    if tg.lower() in last_message_sender.lower() and lastOutgoingMessage!=lastMessage:
+        print(Fore.GREEN + f"{tg}-", end="")
+        print(lastMessage, end="")
+        print(Style.RESET_ALL) 
+    lastOutgoingMessage = lastMessage 

--- a/wplay/terminal_chat.py
+++ b/wplay/terminal_chat.py
@@ -49,7 +49,7 @@ async def chat(target):
             else:
                 await target_select.manual_select_target(page)
             message = io.ask_user_for_message_breakline_mode()
-        if 'switch' in message:
+        if 'switch' in msg or 'Switch' in msg or 'SWITCH' in msg :
             await getMessages(page, target)
 
         # File Share:

--- a/wplay/terminal_chat.py
+++ b/wplay/terminal_chat.py
@@ -31,7 +31,6 @@ async def chat(target):
         target = await target_select.manual_select_target(page)
 
     print("\033[91m {}\033[00m".format("\nType '...' in a new line or alone in the message to change target person.\nType '#_FILE' to send Image/Video/Documentd etc.\n"))
-    print("\033[91m {}\033[00m".format("TYPE 'switch' TO VIEW LAST RECEIVED MESSAGE \n"))
 
     while True:
         await getMessages(page, target)
@@ -76,5 +75,5 @@ async def getMessages(pg, tg):
     if tg.lower() in last_message_sender.lower() and lastOutgoingMessage!=lastMessage:
         print(Fore.GREEN + f"{tg}-", end="")
         print(lastMessage, end="")
-        print(Style.RESET_ALL)
-    lastOutgoingMessage = lastMessage
+        print(Style.RESET_ALL) 
+    lastOutgoingMessage = lastMessage 

--- a/wplay/terminal_chat.py
+++ b/wplay/terminal_chat.py
@@ -31,7 +31,7 @@ async def chat(target):
         target = await target_select.manual_select_target(page)
 
     print("\033[91m {}\033[00m".format("\nType '...' in a new line or alone in the message to change target person.\nType '#_FILE' to send Image/Video/Documentd etc.\n"))
-    print("TYPE 'switch' TO VIEW LAST RECEIVED MESSAGE \n")
+    print("\033[91m {}\033[00m".format("TYPE 'switch' TO VIEW LAST RECEIVED MESSAGE \n"))
 
     while True:
         await getMessages(page, target)

--- a/wplay/terminal_chat.py
+++ b/wplay/terminal_chat.py
@@ -34,6 +34,7 @@ async def chat(target):
         target = await target_select.manual_select_target(page)
 
     print("\033[91m {}\033[00m".format("\nType '...' in a new line or alone in the message to change target person.\nType '#_FILE' to send Image/Video/Documentd etc.\n"))
+    print("TYPE 'switch' TO VIEW LAST RECEIVED MESSAGE \n")
 
     while True:
         await getMessages(page, target)
@@ -57,12 +58,7 @@ async def chat(target):
             await io.send_file(page)
         
         await io.send_message(page, message)
-# import threading
 
-# def printit():
-#     threading.Timer(5.0, printit).start()
-#     print ("Hello, World!")
-# printit() 
 
 lastOutgoingMessage = ''
 

--- a/wplay/terminal_chat.py
+++ b/wplay/terminal_chat.py
@@ -46,16 +46,13 @@ async def chat(target):
             else:
                 await target_select.manual_select_target(page)
             message = io.ask_user_for_message_breakline_mode()
-        if 'switch' in message or 'Switch' in message or 'SWITCH' in message :
-            await getMessages(page, target)
 
         # File Share:
         if '#_FILE' in message:
             message.remove('#_FILE')
             await io.send_file(page)
-
+        await getMessages(page, target)
         await io.send_message(page, message)
-
 
 async def getMessages(pg, tg):
     selector = "#main > div > div > div > div > div > div > div > div"

--- a/wplay/terminal_chat.py
+++ b/wplay/terminal_chat.py
@@ -36,7 +36,7 @@ async def chat(target):
     while True:
         await getMessages(page, target)
         message: list[str] = io.ask_user_for_message_breakline_mode()
-        
+
         if '...' in message:
             message.remove('...')
             await io.send_message(page, message)
@@ -53,7 +53,7 @@ async def chat(target):
         if '#_FILE' in message:
             message.remove('#_FILE')
             await io.send_file(page)
-        
+
         await io.send_message(page, message)
 
 
@@ -79,5 +79,5 @@ async def getMessages(pg, tg):
     if tg.lower() in last_message_sender.lower() and lastOutgoingMessage!=lastMessage:
         print(Fore.GREEN + f"{tg}-", end="")
         print(lastMessage, end="")
-        print(Style.RESET_ALL) 
-    lastOutgoingMessage = lastMessage 
+        print(Style.RESET_ALL)
+    lastOutgoingMessage = lastMessage

--- a/wplay/terminal_chat.py
+++ b/wplay/terminal_chat.py
@@ -75,5 +75,5 @@ async def getMessages(pg, tg):
     if tg.lower() in last_message_sender.lower() and lastOutgoingMessage!=lastMessage:
         print(Fore.GREEN + f"{tg}-", end="")
         print(lastMessage, end="")
-        print(Style.RESET_ALL) 
-    lastOutgoingMessage = lastMessage 
+        print(Style.RESET_ALL)
+    lastOutgoingMessage = lastMessage

--- a/wplay/terminal_chat.py
+++ b/wplay/terminal_chat.py
@@ -26,10 +26,7 @@ async def chat(target):
         except Exception as e:
             print(e)
             await page.reload()
-            await target_search.search_and_select_target_without_new_chat_button(
-                    page,
-                    target
-                    )
+            await target_search.search_and_select_target_without_new_chat_button(page,target)
     else:
         target = await target_select.manual_select_target(page)
 

--- a/wplay/terminal_chat.py
+++ b/wplay/terminal_chat.py
@@ -57,8 +57,6 @@ async def chat(target):
         await io.send_message(page, message)
 
 
-lastOutgoingMessage = ''
-
 async def getMessages(pg, tg):
     selector = "#main > div > div > div > div > div > div > div > div"
     selector_sender = "#main > div > div > div > div > div > div > div > div > div.copyable-text"
@@ -77,7 +75,7 @@ async def getMessages(pg, tg):
     except Exception as e:
         print(e)
         lastMessage = ""
-    global lastOutgoingMessage
+    lastOutgoingMessage = ''
     if tg.lower() in last_message_sender.lower() and lastOutgoingMessage!=lastMessage:
         print(Fore.GREEN + f"{tg}-", end="")
         print(lastMessage, end="")

--- a/wplay/terminal_chat.py
+++ b/wplay/terminal_chat.py
@@ -49,7 +49,7 @@ async def chat(target):
             else:
                 await target_select.manual_select_target(page)
             message = io.ask_user_for_message_breakline_mode()
-        if 'switch' in msg or 'Switch' in msg or 'SWITCH' in msg :
+        if 'switch' in message or 'Switch' in message or 'SWITCH' in message :
             await getMessages(page, target)
 
         # File Share:


### PR DESCRIPTION
## Issue that this pull request solves
#77 
Closes: # (issue number)
#77 
## Proposed changes

Brief description of what is fixed or changed
A function getmessage added which fetches the last message sent by our target.Using Command python3 -m wplay -wc <target> now not only messages are sent but the received messages can be viewed.Now the received messages are displayed automatically after every message sent the received message is displayed.No need to switch or any keyboard interrupt it displays the whole chat.
## Types of changes

_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (Documentation content changed)
- [ ] Other (please describe): 

## Checklist

_Put an `x` in the boxes that apply_

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Screenshots

Please attach the screenshots of the changes made in case of change in user interface
![WhatsApp Image 2020-05-06 at 12 54 22 PM](https://user-images.githubusercontent.com/36266646/81148202-77bf1080-8f99-11ea-84ed-f46daeec89d5.jpeg)

![Screenshot from 2020-05-06 12-54-02](https://user-images.githubusercontent.com/36266646/81148178-6d9d1200-8f99-11ea-91cb-cc8c09962af5.png)

## Other information

Any other information that is important to this pull request
