### PR TITLE
Selecting the target manually now works for -wtf command successfully.

### DIFF
--- a/wplay/utils/target_select.py
+++ b/wplay/utils/target_select.py
@@ -3,9 +3,9 @@ from pathlib import Path
 
 from pyppeteer.page import Page
 
+from wplay.utils import target_search
 from wplay.utils.Logger import Logger
 from wplay.utils.helpers import whatsapp_selectors_dict
-from wplay.utils import target_search
 # endregion
 
 

--- a/wplay/utils/target_select.py
+++ b/wplay/utils/target_select.py
@@ -5,6 +5,7 @@ from pyppeteer.page import Page
 
 from wplay.utils.Logger import Logger
 from wplay.utils.helpers import whatsapp_selectors_dict
+from wplay.utils import target_search
 # endregion
 
 
@@ -15,6 +16,8 @@ async def manual_select_target(page: Page, hide_groups: bool = False):
     target_focused_title = await __get_focused_target_title(page)
     await __wait_for_message_area(page)
     __print_selected_target_title(target_focused_title)
+    complete_target_info =  await target_search.__get_complete_info_on_target(page)
+    target_search.__print_complete_target_info(complete_target_info)
     return target_focused_title
 # endregion
 


### PR DESCRIPTION
## Issue that this pull request solves
#351 
Closes: # (issue number)
#351 
## Proposed changes

Brief description of what is fixed or changed
I discovered that while selecting the target manually no information regarding the target is displayed like it is in case of writing the target in command such as Name, last seen, About common groups etc. Now where target is selected manually all the information is displayed. The issue of -wtf command has been resolved too.
## Types of changes

_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (Documentation content changed)
- [ ] Other (please describe): 

## Checklist

_Put an `x` in the boxes that apply_

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

## Screenshots

Please attach the screenshots of the changes made in case of change in user interface

![Screenshot from 2020-05-21 16-59-39](https://user-images.githubusercontent.com/36266646/82554964-80f8d180-9b84-11ea-8f07-458dcf50d80d.png)

## Other information

Any other information that is important to this pull request
