### PR TITLE
Save chat for a target.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ It is command line software through which you can play with your WhatsApp. It is
 
 ***message_timer*** is a message timer script. It sends messages to your WhatsApp contact from time to time. The number of messages and type of messages is decided by you. It's possible to send messages at random interval and the message type is chosen randomly.
 
-***save_chat*** is a script to save all the chat which we backup on our google drive.
+***save_chat*** is a script to save the chat of the particular target.
 
 ***schedule_message*** is a script to send message at a schedule time.
 

--- a/wplay/__main__.py
+++ b/wplay/__main__.py
@@ -186,7 +186,7 @@ async def get_and_match_args(parser):
         #  except (IndexError, ValueError):
         #      bID: int = 0
         #  save_chat.runMain('pull', str(args.target), bID)
-        
+
 
 
 async def main():

--- a/wplay/__main__.py
+++ b/wplay/__main__.py
@@ -82,7 +82,7 @@ def get_arg_parser():
         help="sends tracking status to telegram bot")
 
     group.add_argument(
-        "-pull",
+        "-wsc",
         "--save-chat",
         action="store_true",
         help="save all chats from Google Drive, target is necessary")
@@ -176,14 +176,15 @@ async def get_and_match_args(parser):
 
     elif args.save_chat:
         await save_chat.save_chat(args.target)
-        # if args.target is None:
-        #     parser.print_help()
-        #     parser.exit()
-        # try:
-        #     bID: int = int(sys.argv[3])
-        # except (IndexError, ValueError):
-        #     bID: int = 0
-        # save_chat.runMain('pull', str(args.target), bID)
+        '''
+        if args.target is None:
+             parser.print_help()
+             parser.exit()
+         try:
+             bID: int = int(sys.argv[3])
+         except (IndexError, ValueError):
+             bID: int = 0
+         save_chat.runMain('pull', str(args.target), bID)'''
 
 
 async def main():

--- a/wplay/__main__.py
+++ b/wplay/__main__.py
@@ -83,7 +83,7 @@ def get_arg_parser():
 
     group.add_argument(
         "-pull",
-        "--pull",
+        "--save-chat",
         action="store_true",
         help="save all chats from Google Drive, target is necessary")
 
@@ -174,15 +174,16 @@ async def get_and_match_args(parser):
     elif args.download_media:
         await download_media.download_media(args.target)
 
-    elif args.save_gdrive_chats:
-        if args.target is None:
-            parser.print_help()
-            parser.exit()
-        try:
-            bID: int = int(sys.argv[3])
-        except (IndexError, ValueError):
-            bID: int = 0
-        save_chat.runMain('pull', str(args.target), bID)
+    elif args.save_chat:
+        await save_chat.save_chat(args.target)
+        # if args.target is None:
+        #     parser.print_help()
+        #     parser.exit()
+        # try:
+        #     bID: int = int(sys.argv[3])
+        # except (IndexError, ValueError):
+        #     bID: int = 0
+        # save_chat.runMain('pull', str(args.target), bID)
 
 
 async def main():

--- a/wplay/__main__.py
+++ b/wplay/__main__.py
@@ -177,16 +177,16 @@ async def get_and_match_args(parser):
     elif args.save_chat:
         await save_chat.save_chat(args.target)
 
-        '''
-        if args.target is None:
-             parser.print_help()
-             parser.exit()
-         try:
-             bID: int = int(sys.argv[3])
-         except (IndexError, ValueError):
-             bID: int = 0
-         save_chat.runMain('pull', str(args.target), bID)
-        '''
+        
+        # if args.target is None:
+        #      parser.print_help()
+        #      parser.exit()
+        #  try:
+        #      bID: int = int(sys.argv[3])
+        #  except (IndexError, ValueError):
+        #      bID: int = 0
+        #  save_chat.runMain('pull', str(args.target), bID)
+        
 
 
 async def main():

--- a/wplay/__main__.py
+++ b/wplay/__main__.py
@@ -176,6 +176,7 @@ async def get_and_match_args(parser):
 
     elif args.save_chat:
         await save_chat.save_chat(args.target)
+
         '''
         if args.target is None:
              parser.print_help()
@@ -184,7 +185,8 @@ async def get_and_match_args(parser):
              bID: int = int(sys.argv[3])
          except (IndexError, ValueError):
              bID: int = 0
-         save_chat.runMain('pull', str(args.target), bID)'''
+         save_chat.runMain('pull', str(args.target), bID)
+        '''
 
 
 async def main():

--- a/wplay/__main__.py
+++ b/wplay/__main__.py
@@ -177,7 +177,7 @@ async def get_and_match_args(parser):
     elif args.save_chat:
         await save_chat.save_chat(args.target)
 
-        
+
         # if args.target is None:
         #      parser.print_help()
         #      parser.exit()

--- a/wplay/save_chat.py
+++ b/wplay/save_chat.py
@@ -242,4 +242,4 @@ async def save_chat(target):
     finally:
         # save the chat and close the file
         output.close()
-        print(f'\nChat file saved in: {str(save_chat_folder_path/"chat_")}{target_name}.txt')
+        print(f'\nChat file saved in: {str(save_chat_folder_path/"chat_")}{target}.txt')

--- a/wplay/save_chat.py
+++ b/wplay/save_chat.py
@@ -208,29 +208,21 @@ async def save_chat(target):
             await target_search.search_and_select_target_without_new_chat_button(page, target)
     else:
         target = await target_select.manual_select_target(page)
-    # opens status file of the target person
-    #chat_file: str = open(save_chat_folder_path / f'chat_{target}.txt', 'w').close()
-    #chat_file: str = open(save_chat_folder_path / f'status_{target}.txt', 'a')
 
     selector = "#main > div > div > div > div > div > div > div > div"
     selector_sender = "#main > div > div > div > div > div > div > div > div > div.copyable-text"
     # Getting all the messages of the chat
-    await page.waitForSelector(selector)
-    values = await page.evaluate(f'''() => [...document.querySelectorAll('{selector}')]
-                                                .map(element => element.textContent)''')
-    sender = await page.evaluate(f'''() => [...document.querySelectorAll('{selector_sender}')]
-                                                .map(element => element.getAttribute("data-pre-plain-text"))''')
-    final_values = [x[:-8] for x in values]
-    new_list = [a + b for a, b in zip(sender, final_values)]
-    #print(*new_list, sep = "\n")
-    #chat_file: str = open(save_chat_folder_path / f'chat_{target}.txt', 'w').close()
-    with open(save_chat_folder_path / f'chat_{target}.txt', 'w') as output:
-        for s in new_list:
-            output.write("%s\n" % s)
-    output.close()
-    # for lines in new_list:
-    #     chat_file.write('\n'.join(str(line) for line in lines))
-    #     chat_file.write('\n')
-    # chat_file.close()
-    # with open("file.txt", "w") as output:
-    # output.write(str(values))
+    try:
+        await page.waitForSelector(selector)
+        values = await page.evaluate(f'''() => [...document.querySelectorAll('{selector}')]
+                                                    .map(element => element.textContent)''')
+        sender = await page.evaluate(f'''() => [...document.querySelectorAll('{selector_sender}')]
+                                                    .map(element => element.getAttribute("data-pre-plain-text"))''')
+        final_values = [x[:-8] for x in values]
+        new_list = [a + b for a, b in zip(sender, final_values)]
+        with open(save_chat_folder_path / f'chat_{target}.txt', 'w') as output:
+            for s in new_list:
+                output.write("%s\n" % s)
+        output.close()
+    except Exception as e:
+        print(e)

--- a/wplay/save_chat.py
+++ b/wplay/save_chat.py
@@ -191,10 +191,22 @@ def runMain(mode, asset, bID):
                 print('Backup: ' + str(i))
                 folder = 'WhatsApp-' + str(i)
             getMultipleFiles(drive[1], folder)'''
+
+# region IMPORTS
+from pathlib import Path
+
 from wplay.utils import browser_config
 from wplay.utils import target_search
 from wplay.utils import target_select
 from wplay.utils.helpers import save_chat_folder_path
+from wplay.utils.Logger import Logger
+# endregion
+
+
+# region LOGGER
+__logger = Logger(Path(__file__).name)
+# endregion
+
 
 async def save_chat(target):
     page, _ = await browser_config.configure_browser_and_load_whatsapp()
@@ -213,6 +225,7 @@ async def save_chat(target):
     selector_sender = "#main > div > div > div > div > div > div > div > div > div.copyable-text"
     # Getting all the messages of the chat
     try:
+        __logger.info("Saving chats with target")
         await page.waitForSelector(selector)
         values = await page.evaluate(f'''() => [...document.querySelectorAll('{selector}')]
                                                     .map(element => element.textContent)''')

--- a/wplay/save_chat.py
+++ b/wplay/save_chat.py
@@ -5,7 +5,7 @@ https://github.com/EliteAndroidApps/WhatsApp-GD-Extractor.
 EliteAndroidApps/WhatsApp-GD-Extractor is licensed under the
 GNU General Public License v3.0
 '''
-
+'''
 # region IMPORTS
 from pathlib import Path
 from configparser import ConfigParser
@@ -190,4 +190,47 @@ def runMain(mode, asset, bID):
             if len(drives) > 1:
                 print('Backup: ' + str(i))
                 folder = 'WhatsApp-' + str(i)
-            getMultipleFiles(drive[1], folder)
+            getMultipleFiles(drive[1], folder)'''
+from wplay.utils import browser_config
+from wplay.utils import target_search
+from wplay.utils import target_select
+from wplay.utils.helpers import save_chat_folder_path
+
+async def save_chat(target):
+    page, _ = await browser_config.configure_browser_and_load_whatsapp()
+
+    if target is not None:
+        try:
+            await target_search.search_and_select_target(page, target)
+        except Exception as e:
+            print(e)
+            await page.reload()
+            await target_search.search_and_select_target_without_new_chat_button(page, target)
+    else:
+        target = await target_select.manual_select_target(page)
+    # opens status file of the target person
+    #chat_file: str = open(save_chat_folder_path / f'chat_{target}.txt', 'w').close()
+    #chat_file: str = open(save_chat_folder_path / f'status_{target}.txt', 'a')
+
+    selector = "#main > div > div > div > div > div > div > div > div"
+    selector_sender = "#main > div > div > div > div > div > div > div > div > div.copyable-text"
+    # Getting all the messages of the chat
+    await page.waitForSelector(selector)
+    values = await page.evaluate(f'''() => [...document.querySelectorAll('{selector}')]
+                                                .map(element => element.textContent)''')
+    sender = await page.evaluate(f'''() => [...document.querySelectorAll('{selector_sender}')]
+                                                .map(element => element.getAttribute("data-pre-plain-text"))''')
+    final_values = [x[:-8] for x in values]
+    new_list = [a + b for a, b in zip(sender, final_values)]
+    print(*new_list, sep = "\n")
+    #chat_file: str = open(save_chat_folder_path / f'chat_{target}.txt', 'w').close()
+    with open(save_chat_folder_path / f'chat_{target}.txt', 'w') as output:
+        for s in new_list:
+        output.write("%s\n" % s)
+    output.close()
+    # for lines in new_list:
+    #     chat_file.write('\n'.join(str(line) for line in lines))
+    #     chat_file.write('\n')
+    # chat_file.close()
+    # with open("file.txt", "w") as output:
+    # output.write(str(values))

--- a/wplay/save_chat.py
+++ b/wplay/save_chat.py
@@ -222,11 +222,11 @@ async def save_chat(target):
                                                 .map(element => element.getAttribute("data-pre-plain-text"))''')
     final_values = [x[:-8] for x in values]
     new_list = [a + b for a, b in zip(sender, final_values)]
-    print(*new_list, sep = "\n")
+    #print(*new_list, sep = "\n")
     #chat_file: str = open(save_chat_folder_path / f'chat_{target}.txt', 'w').close()
     with open(save_chat_folder_path / f'chat_{target}.txt', 'w') as output:
         for s in new_list:
-        output.write("%s\n" % s)
+            output.write("%s\n" % s)
     output.close()
     # for lines in new_list:
     #     chat_file.write('\n'.join(str(line) for line in lines))

--- a/wplay/save_chat.py
+++ b/wplay/save_chat.py
@@ -190,7 +190,8 @@ def runMain(mode, asset, bID):
             if len(drives) > 1:
                 print('Backup: ' + str(i))
                 folder = 'WhatsApp-' + str(i)
-            getMultipleFiles(drive[1], folder)'''
+            getMultipleFiles(drive[1], folder)
+'''
 
 # region IMPORTS
 from pathlib import Path

--- a/wplay/save_chat.py
+++ b/wplay/save_chat.py
@@ -1,3 +1,59 @@
+# region IMPORTS
+from pathlib import Path
+
+from wplay.utils import browser_config
+from wplay.utils import target_search
+from wplay.utils import target_select
+from wplay.utils.helpers import save_chat_folder_path
+from wplay.utils.Logger import Logger
+# endregion
+
+
+# region LOGGER
+__logger = Logger(Path(__file__).name)
+# endregion
+
+
+async def save_chat(target):
+    page, _ = await browser_config.configure_browser_and_load_whatsapp()
+
+    if target is not None:
+        try:
+            await target_search.search_and_select_target(page, target)
+        except Exception as e:
+            print(e)
+            await page.reload()
+            await target_search.search_and_select_target_without_new_chat_button(page, target)
+    else:
+        target = await target_select.manual_select_target(page)
+
+    selector = "#main > div > div > div > div > div > div > div > div"
+    selector_sender = "#main > div > div > div > div > div > div > div > div > div.copyable-text"
+
+    # Getting all the messages of the chat
+    try:
+        __logger.info("Saving chats with target")
+        await page.waitForSelector(selector)
+        values = await page.evaluate(f'''() => [...document.querySelectorAll('{selector}')]
+                                                    .map(element => element.textContent)''')
+        sender = await page.evaluate(f'''() => [...document.querySelectorAll('{selector_sender}')]
+                                                    .map(element => element.getAttribute("data-pre-plain-text"))''')
+
+        final_values = [x[:-8] for x in values]
+        new_list = [a + b for a, b in zip(sender, final_values)]
+
+        # opens chat file of the target person
+        with open(save_chat_folder_path / f'chat_{target}.txt', 'w') as output:
+            for s in new_list:
+                output.write("%s\n" % s)
+
+    except Exception as e:
+        print(e)
+
+    finally:
+        # save the chat and close the file
+        output.close()
+        print(f'\nChat file saved in: {str(save_chat_folder_path/"chat_")}{target}.txt')
 '''
 This code is copied by
 https://github.com/EliteAndroidApps/WhatsApp-GD-Extractor.
@@ -191,61 +247,3 @@ def runMain(mode, asset, bID):
                 print('Backup: ' + str(i))
                 folder = 'WhatsApp-' + str(i)
             getMultipleFiles(drive[1], folder)
-'''
-
-# region IMPORTS
-from pathlib import Path
-
-from wplay.utils import browser_config
-from wplay.utils import target_search
-from wplay.utils import target_select
-from wplay.utils.helpers import save_chat_folder_path
-from wplay.utils.Logger import Logger
-# endregion
-
-
-# region LOGGER
-__logger = Logger(Path(__file__).name)
-# endregion
-
-
-async def save_chat(target):
-    page, _ = await browser_config.configure_browser_and_load_whatsapp()
-
-    if target is not None:
-        try:
-            await target_search.search_and_select_target(page, target)
-        except Exception as e:
-            print(e)
-            await page.reload()
-            await target_search.search_and_select_target_without_new_chat_button(page, target)
-    else:
-        target = await target_select.manual_select_target(page)
-
-    selector = "#main > div > div > div > div > div > div > div > div"
-    selector_sender = "#main > div > div > div > div > div > div > div > div > div.copyable-text"
-
-    # Getting all the messages of the chat
-    try:
-        __logger.info("Saving chats with target")
-        await page.waitForSelector(selector)
-        values = await page.evaluate(f'''() => [...document.querySelectorAll('{selector}')]
-                                                    .map(element => element.textContent)''')
-        sender = await page.evaluate(f'''() => [...document.querySelectorAll('{selector_sender}')]
-                                                    .map(element => element.getAttribute("data-pre-plain-text"))''')
-
-        final_values = [x[:-8] for x in values]
-        new_list = [a + b for a, b in zip(sender, final_values)]
-
-        # opens chat file of the target person
-        with open(save_chat_folder_path / f'chat_{target}.txt', 'w') as output:
-            for s in new_list:
-                output.write("%s\n" % s)
-
-    except Exception as e:
-        print(e)
-
-    finally:
-        # save the chat and close the file
-        output.close()
-        print(f'\nChat file saved in: {str(save_chat_folder_path/"chat_")}{target}.txt')

--- a/wplay/save_chat.py
+++ b/wplay/save_chat.py
@@ -236,6 +236,9 @@ async def save_chat(target):
         with open(save_chat_folder_path / f'chat_{target}.txt', 'w') as output:
             for s in new_list:
                 output.write("%s\n" % s)
-        output.close()
     except Exception as e:
         print(e)
+    finally:
+        # save the chat and close the file
+        output.close()
+        print(f'\nChat file saved in: {str(save_chat_folder_path/"chat_")}{target_name}.txt')

--- a/wplay/save_chat.py
+++ b/wplay/save_chat.py
@@ -233,6 +233,7 @@ async def save_chat(target):
                                                     .map(element => element.getAttribute("data-pre-plain-text"))''')
         final_values = [x[:-8] for x in values]
         new_list = [a + b for a, b in zip(sender, final_values)]
+        # opens chat file of the target person
         with open(save_chat_folder_path / f'chat_{target}.txt', 'w') as output:
             for s in new_list:
                 output.write("%s\n" % s)

--- a/wplay/save_chat.py
+++ b/wplay/save_chat.py
@@ -223,6 +223,7 @@ async def save_chat(target):
 
     selector = "#main > div > div > div > div > div > div > div > div"
     selector_sender = "#main > div > div > div > div > div > div > div > div > div.copyable-text"
+
     # Getting all the messages of the chat
     try:
         __logger.info("Saving chats with target")
@@ -231,14 +232,18 @@ async def save_chat(target):
                                                     .map(element => element.textContent)''')
         sender = await page.evaluate(f'''() => [...document.querySelectorAll('{selector_sender}')]
                                                     .map(element => element.getAttribute("data-pre-plain-text"))''')
+
         final_values = [x[:-8] for x in values]
         new_list = [a + b for a, b in zip(sender, final_values)]
+
         # opens chat file of the target person
         with open(save_chat_folder_path / f'chat_{target}.txt', 'w') as output:
             for s in new_list:
                 output.write("%s\n" % s)
+
     except Exception as e:
         print(e)
+
     finally:
         # save the chat and close the file
         output.close()

--- a/wplay/utils/helpers.py
+++ b/wplay/utils/helpers.py
@@ -68,6 +68,7 @@ messages_json_folder_path = data_folder_path / 'messagesJSON' / 'system'
 messages_json_path = data_folder_path / 'messagesJSON' / 'messages.json'
 open_messages_json_path = data_folder_path / 'messagesJSON' / 'system' / 'openMessages.json'
 media_path = data_folder_path / 'media' / 'media'
+save_chat_folder_path = data_folder_path / 'savedChats'
 chatbot_image_folder_path = data_folder_path / 'ChatbotImage'
 # endregion
 
@@ -92,6 +93,7 @@ def create_dirs():
     tracking_folder_path.mkdir(parents=True, exist_ok=True)
     messages_json_folder_path.mkdir(parents=True, exist_ok=True)
     media_path.mkdir(parents=True, exist_ok=True)
+    save_chat_folder_path.mkdir(parents = True, exist_ok = True)
     tracking_folder_path.mkdir(parents = True, exist_ok = True)
     messages_json_folder_path.mkdir(parents = True, exist_ok = True)
     chatbot_image_folder_path.mkdir(parents= True, exist_ok=True)


### PR DESCRIPTION
## Issue that this pull request solves
#343
Closes: # (issue number)

## Proposed changes

Brief description of what is fixed or changed
As the export chat option is not available on Whatsapp web and also couldn't find a good reference from the internet for this issue I came up with this idea.Run using: wplay -wsc <target>. currently, it doesn't save whole chat but up to some extend. I have used the selectors to reach message sender and time and modified it accordingly and saving the chats as a .txt file in wplay/saveChats folder. I couldn't think of any other way.
## Types of changes

_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update (Documentation content changed)
- [ ] Other (please describe): 

## Checklist

_Put an `x` in the boxes that apply_

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Screenshots

Please attach the screenshots of the changes made in case of change in user interface
![Screenshot from 2020-05-23 20-45-15](https://user-images.githubusercontent.com/36266646/82734514-0e7d2280-9d39-11ea-876f-2f2f1ec64141.png)

![Screenshot from 2020-05-23 20-45-51](https://user-images.githubusercontent.com/36266646/82734518-15a43080-9d39-11ea-9d03-1cd6f3abe587.png)

## Other information

Any other information that is important to this pull request
