### PR TITLE
Recent chat target specific displayed before chat starts.

### DIFF
--- a/wplay/terminal_chat.py
+++ b/wplay/terminal_chat.py
@@ -33,10 +33,28 @@ async def chat(target):
     else:
         target = await target_select.manual_select_target(page)
 
+    selector = "#main > div > div > div > div > div > div > div > div"
+    selector_sender = "#main > div > div > div > div > div > div > div > div > div.copyable-text"
+
+    # Getting all the messages of the chat
+    try:
+        __logger.info("Printing recent chat")
+        await page.waitForSelector(selector)
+        values = await page.evaluate(f'''() => [...document.querySelectorAll('{selector}')]
+                                                    .map(element => element.textContent)''')
+        sender = await page.evaluate(f'''() => [...document.querySelectorAll('{selector_sender}')]
+                                                    .map(element => element.getAttribute("data-pre-plain-text"))''')
+        new_values = [x[:-8] for x in values]
+        new_list = [a + b for a, b in zip(sender, new_values)]
+        final_list = new_list[-6:] 
+        for s in final_list:
+            print("%s\n" % s)
+    except Exception as e:
+        print(e)
+
     print("\033[91m {}\033[00m".format("\nType '...' in a new line or alone in the message to change target person.\nType '#_FILE' to send Image/Video/Documentd etc.\nType '#_TTS' to convert text to speech and send audio file.\nType '#_FWD' to foward your last message received"))
 
     while True:
-        await getMessages(page, target)
         message: list[str] = io.ask_user_for_message_breakline_mode()
 
         #Target Change


### PR DESCRIPTION
## Issue that this pull request solves
#299 
Closes: # (issue number)
#299 
## Proposed changes

Brief description of what is fixed or changed
Now the user when inputs command 'wplay -wc <target>' recent chat with that target will be displayed around 5-6 last messages and then usual we can chat and that last message received will be printed.
## Types of changes

_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (Documentation content changed)
- [ ] Other (please describe): 

## Checklist

_Put an `x` in the boxes that apply_

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Screenshots

Please attach the screenshots of the changes made in case of change in user interface
![Screenshot from 2020-05-31 17-55-13](https://user-images.githubusercontent.com/36266646/83352267-f2483980-a367-11ea-82b6-a646b1aa75df.png)

## Other information

Any other information that is important to this pull request
